### PR TITLE
Vitestでユニットテストを作成出来る設定を追加

### DIFF
--- a/ai-agent-sandbox-frontend/package.json
+++ b/ai-agent-sandbox-frontend/package.json
@@ -12,7 +12,9 @@
     "format": "ultracite fix && npm run prettier",
     "sync:agents-docs": "npx tsx src/scripts/copy-agents-markdown.ts",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test:storybook": "vitest run --project storybook",
+    "test": "vitest run --project unit"
   },
   "dependencies": {
     "@ai-sdk/openai": "2.0.59",

--- a/ai-agent-sandbox-frontend/src/lib/mb-string.ts
+++ b/ai-agent-sandbox-frontend/src/lib/mb-string.ts
@@ -1,0 +1,54 @@
+// 絶対厳守：編集前に必ずAI実装ルールを読む
+const HIGH_SURROGATE_START = 0xd8_00;
+const HIGH_SURROGATE_END = 0xdb_ff;
+const LOW_SURROGATE_START = 0xdc_00;
+const LOW_SURROGATE_END = 0xdf_ff;
+
+const isSurrogatePear = (upper: number, lower: number): boolean =>
+  upper >= HIGH_SURROGATE_START &&
+  upper <= HIGH_SURROGATE_END &&
+  lower >= LOW_SURROGATE_START &&
+  lower <= LOW_SURROGATE_END;
+
+export const mbStrLen = (str: string): number => {
+  let logicalLength = 0;
+  let index = 0;
+
+  while (index < str.length) {
+    const upper = str.charCodeAt(index);
+    const nextIndex = index + 1;
+    const lower = nextIndex < str.length ? str.charCodeAt(nextIndex) : 0;
+    const step = isSurrogatePear(upper, lower) ? 2 : 1;
+
+    logicalLength += 1;
+    index += step;
+  }
+
+  return logicalLength;
+};
+
+export const mbString = (str: string, begin: number, end: number): string => {
+  let result = "";
+  let logicalIndex = 0;
+  let rawIndex = 0;
+
+  while (rawIndex < str.length) {
+    const upper = str.charCodeAt(rawIndex);
+    const nextIndex = rawIndex + 1;
+    const lower = nextIndex < str.length ? str.charCodeAt(nextIndex) : 0;
+    const isPair = isSurrogatePear(upper, lower);
+    const step = isPair ? 2 : 1;
+    const segment = isPair
+      ? String.fromCharCode(upper, lower)
+      : String.fromCharCode(upper);
+
+    if (begin <= logicalIndex && logicalIndex < end) {
+      result += segment;
+    }
+
+    logicalIndex += 1;
+    rawIndex += step;
+  }
+
+  return result;
+};

--- a/ai-agent-sandbox-frontend/src/lib/mb-string/mb-str-len.test.ts
+++ b/ai-agent-sandbox-frontend/src/lib/mb-string/mb-str-len.test.ts
@@ -1,0 +1,34 @@
+// 絶対厳守：編集前に必ずAI実装ルールを読む
+import { describe, expect, it } from "vitest";
+
+import { mbStrLen } from "../mb-string";
+
+describe("src/lib/mb-string.ts mbStrLen", () => {
+  type TestTable = {
+    description: string;
+    text: string;
+    expected: number;
+  };
+
+  const asciiText = "hello";
+  const asciiExpected = Array.from(asciiText).length;
+
+  const emojiText = "😀😃";
+  const emojiExpected = Array.from(emojiText).length;
+
+  const mixedText = "A😀BC🇯🇵";
+  const mixedExpected = Array.from(mixedText).length;
+
+  const emptyText = "";
+  const emptyExpected = Array.from(emptyText).length;
+
+  it.each`
+    description                         | text         | expected
+    ${"ASCII文字列の長さを返す"}        | ${asciiText} | ${asciiExpected}
+    ${"サロゲートペアのみの長さを返す"} | ${emojiText} | ${emojiExpected}
+    ${"混在した文字列の長さを返す"}     | ${mixedText} | ${mixedExpected}
+    ${"空文字列は0を返す"}              | ${emptyText} | ${emptyExpected}
+  `("$description", ({ text, expected }: TestTable) => {
+    expect(mbStrLen(text)).toBe(expected);
+  });
+});

--- a/ai-agent-sandbox-frontend/src/lib/mb-string/mb-sub-str.test.ts
+++ b/ai-agent-sandbox-frontend/src/lib/mb-string/mb-sub-str.test.ts
@@ -1,0 +1,57 @@
+// 絶対厳守：編集前に必ずAI実装ルールを読む
+import { describe, expect, it } from "vitest";
+
+import { mbString } from "../mb-string";
+
+describe("src/lib/mb-string.ts mbString", () => {
+  type TestTable = {
+    description: string;
+    text: string;
+    begin: number;
+    end: number;
+    expected: string;
+  };
+
+  const ZERO = 0;
+
+  const hello = "hello";
+  const separator = " ";
+  const world = "world";
+  const asciiText = `${hello}${separator}${world}`;
+  const helloLength = Array.from(hello).length;
+  const separatorLength = Array.from(separator).length;
+  const worldLength = Array.from(world).length;
+  const worldStart = helloLength + separatorLength;
+  const worldEnd = worldStart + worldLength;
+
+  const prefix = "A";
+  const emoji = "😀";
+  const middle = "BC";
+  const flag = "🇯🇵";
+  const surrogateText = `${prefix}${emoji}${middle}${flag}`;
+  const codePoints = Array.from(surrogateText);
+  const emojiStart = codePoints.indexOf(emoji);
+  const emojiEnd = emojiStart + 1;
+  const middleEnd = emojiEnd + Array.from(middle).length;
+  const flagLength = Array.from(flag).length;
+  const flagStart = codePoints.length - flagLength;
+  const flagEnd = flagStart + flagLength;
+
+  const overflowText = "こんにちは世界";
+  const overflowTotalLength = Array.from(overflowText).length;
+  const overflowBegin = Array.from("こん").length;
+  const overshootEnd = overflowTotalLength + Array.from("追加").length;
+
+  it.each`
+    description                               | text             | begin                  | end             | expected
+    ${"ASCII: 先頭部分を取得する"}            | ${asciiText}     | ${ZERO}                | ${helloLength}  | ${hello}
+    ${"ASCII: 後半部分を取得する"}            | ${asciiText}     | ${worldStart}          | ${worldEnd}     | ${world}
+    ${"サロゲート: 絵文字のみ取得する"}       | ${surrogateText} | ${emojiStart}          | ${emojiEnd}     | ${emoji}
+    ${"サロゲート: 先頭からASCIIまで取得"}    | ${surrogateText} | ${ZERO}                | ${middleEnd}    | ${`${prefix}${emoji}${middle}`}
+    ${"サロゲート: 国旗を取得する"}           | ${surrogateText} | ${flagStart}           | ${flagEnd}      | ${flag}
+    ${"範囲外: 終端超過でも切り出せる"}       | ${overflowText}  | ${overflowBegin}       | ${overshootEnd} | ${"にちは世界"}
+    ${"範囲外: 開始位置が終端以上なら空文字"} | ${overflowText}  | ${overflowTotalLength} | ${overshootEnd} | ${""}
+  `("$description", ({ text, begin, end, expected }: TestTable) => {
+    expect(mbString(text, begin, end)).toBe(expected);
+  });
+});

--- a/ai-agent-sandbox-frontend/vitest.config.ts
+++ b/ai-agent-sandbox-frontend/vitest.config.ts
@@ -1,3 +1,4 @@
+// 絶対厳守：編集前に必ずAI実装ルールを読む
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
@@ -11,8 +12,20 @@ const dirname =
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.join(dirname, "src"),
+    },
+  },
   test: {
     projects: [
+      {
+        test: {
+          name: "unit",
+          include: ["src/**/*.test.ts"],
+          environment: "node",
+        },
+      },
       {
         extends: true,
         plugins: [


### PR DESCRIPTION
## 目的
- フロントエンドで単体テストを実行するためのVitest設定が未整備だったため、テスト基盤を用意します。
- マルチバイト文字列を扱うユーティリティの挙動を自動検証できるようにし、レグレッションを防ぎます。

## 変更内容
- Vitestのルート設定にユニットテスト用プロジェクトを追加し、`@` エイリアスを解決できるようにしました。
- Storybook向けの既存プロジェクト設定を維持したまま、unit向けとstorybook向けのテストコマンドをnpm scriptに追加しました。
- サロゲートペアを考慮した `mbStrLen`/`mbString` 関数を `src/lib/mb-string.ts` として整理し、Vitestのテーブル駆動テストを追加しました。

## 影響範囲
- `npm run test` がVitestのunitプロジェクトを実行するようになります。
- Storybook用テストは `npm run test:storybook` で従来通り実行可能です。
- マルチバイト文字列の挙動を利用する箇所で、今後ユーティリティ関数とテストを共有できます。

## 対応Issue
- #11